### PR TITLE
1557 FluxBufferTimeout greediness

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -109,6 +109,12 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 		static final AtomicLongFieldUpdater<BufferTimeoutSubscriber> REQUESTED =
 				AtomicLongFieldUpdater.newUpdater(BufferTimeoutSubscriber.class, "requested");
 
+		volatile long outstandingRequestedFromUpstream;
+
+		@SuppressWarnings("rawtypes")
+		static final AtomicLongFieldUpdater<BufferTimeoutSubscriber> OUTSTANDING_REQUESTED_FROM_UPSTREAM =
+				AtomicLongFieldUpdater.newUpdater(BufferTimeoutSubscriber.class, "outstandingRequestedFromUpstream");
+
 		volatile int index = 0;
 
 		static final AtomicIntegerFieldUpdater<BufferTimeoutSubscriber> INDEX =
@@ -162,6 +168,24 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 					values = v;
 				}
 				v.add(value);
+
+				long next;
+				long o = outstandingRequestedFromUpstream;
+				if (o != 0) {
+					for (; ; ) {
+						next = o - 1;
+						if (OUTSTANDING_REQUESTED_FROM_UPSTREAM.compareAndSet(this,
+								o,
+								next)) {
+							break;
+						}
+						o = outstandingRequestedFromUpstream;
+						if (o <= 0L)
+						{
+							break;
+						}
+					}
+				}
 			}
 		}
 
@@ -289,7 +313,8 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 					requestMore(Long.MAX_VALUE);
 				}
 				else {
-					requestMore(Operators.multiplyCap(n, batchSize));
+					long requestCap = Operators.multiplyCap(requested, batchSize);
+					requestMore(requestCap - outstandingRequestedFromUpstream);
 				}
 			}
 		}
@@ -298,6 +323,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 			Subscription s = this.subscription;
 			if (s != null) {
 				s.request(n);
+				Operators.addCap(OUTSTANDING_REQUESTED_FROM_UPSTREAM, this, n);
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -311,8 +311,8 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 					requestMore(Long.MAX_VALUE);
 				}
 				else {
-					long requestCap = Operators.multiplyCap(requested, batchSize);
-					requestMore(requestCap - outstanding);
+					long requestLimit = Operators.multiplyCap(requested, batchSize);
+					requestMore(requestLimit - outstanding);
 				}
 			}
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -204,7 +204,7 @@ public class FluxBufferTimeoutTest {
 	}
 
 	@Test
-	public void requestedFromUpstreamShouldNotExceeddownstreamDemand() {
+	public void requestedFromUpstreamShouldNotExceedDownstreamDemand() {
 		Subscription[] subscriptionsHolder = new Subscription[1];
 		CoreSubscriber<List<String>> actual = new LambdaSubscriber<>(null, e -> {}, null, s -> subscriptionsHolder[0] = s);
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,6 +233,7 @@ public class FluxBufferTimeoutTest {
 
 		timeScheduler.advanceTimeBy(Duration.ofMillis(100));
 		assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(1L);
+		assertThat(test.outstanding).isEqualTo(5L);
 		assertThat(requestedOutstanding.get()).isEqualTo(5L);
 
 		test.onNext(String.valueOf("0"));
@@ -240,10 +241,12 @@ public class FluxBufferTimeoutTest {
 
 		timeScheduler.advanceTimeBy(Duration.ofMillis(100));
 		assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(0L);
+		assertThat(test.outstanding).isEqualTo(4L);
 		assertThat(requestedOutstanding.get()).isEqualTo(4L);
 
 		subscriptionsHolder[0].request(1);
 		assertThat(test.scan(Scannable.Attr.REQUESTED_FROM_DOWNSTREAM)).isEqualTo(1L);
+		assertThat(test.outstanding).isEqualTo(5L);
 		assertThat(requestedOutstanding.get()).isEqualTo(5L);
 	}
 


### PR DESCRIPTION
This solves the problem of FluxBufferTimeout being overly greedy in the number of items it requests from upstream.

The previous behaviour for a FluxBufferTimeout with N=5:
1 - Downstream requests 1 buffer
2 - A request is made upstream for 1*N=5 items
3 - Upstream sends 1 item
4 - Buffer times out, sending a buffer containing a single item downstream
5 - downstream requests 1 buffer
6 - A request is made upstream for another 5 items

The result is that 9 outstanding requests have been made upstream, when the buffer can only hold 5 items. This increases the risks of the failWithOverflow error.

The solution is to hold an internal counter of the number of outstanding requests made upstream

The new behaviour for a FluxBufferTimeout with N=5:
1 - Downstream requests 1 buffer
2 - A request is made upstream for 1*N=5 items, setting the number of outstanding requests to 5
3 - Upstream sends 1 item, decreasing the number of outstanding requests to 4
4 - Buffer times out, sending a buffer containing a single item downstream
5 - downstream requests 1 buffer
6 - Since there are already 4 outstanding requests, only a single item is requested from upstream, bringing the number of outstanding requests up to 5